### PR TITLE
V-Angular - Dropdown - Added "close on scroll" function

### DIFF
--- a/libs/angular/src/v-angular/dropdown/dropdown.component.html
+++ b/libs/angular/src/v-angular/dropdown/dropdown.component.html
@@ -59,7 +59,10 @@
 
   <!-- INPUT -->
   <ng-container *ngIf="!locked">
-    <div class="gds-input-wrapper dropdown-wrapper">
+    <div
+      class="gds-input-wrapper dropdown-wrapper"
+      [ngClass]="{ 'close-on-scroll': closeOnScroll === true }"
+    >
       <div #input [id]="id + '-input'" class="dropdown">
         <button
           [id]="id + '-toggle'"

--- a/libs/angular/src/v-angular/dropdown/dropdown.component.scss
+++ b/libs/angular/src/v-angular/dropdown/dropdown.component.scss
@@ -156,4 +156,9 @@
       margin-top: 0.25rem;
     }
   }
+  .close-on-scroll {
+    ::ng-deep nggv-dropdown-list ul[role='listbox'] {
+      overscroll-behavior: none;
+    }
+  }
 }

--- a/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/v-angular/dropdown/dropdown.stories.ts
@@ -615,6 +615,33 @@ const ComboTemplate: StoryFn<StoryArgs> = (args: any) => {
   }
 }
 
+const WithCloseOnScrollTemplate: StoryFn<StoryArgs> = (args: any) => {
+  const formControl = new UntypedFormControl({ value: '' })
+  return {
+    template: /*html*/ `
+  <div style="height: 1000px;">
+    <nggv-dropdown
+      [label]="label"
+      [placeholder]="placeholder"
+      [options]="options"
+      [required]="required"
+      [invalid]="invalid"
+      [disabled]="disabled"
+      [error]="error"
+      [size]="size"
+      [closeOnScroll]="closeOnScroll"
+      [formControl]="formControl">
+
+      <ng-template #labelTpl>Custom Label</ng-template>
+
+      <ng-template let-option #optionTpl>{{option.label | transloco}} {{option.accountNumber}}</ng-template>
+
+    </nggv-dropdown>
+  </div>`,
+    props: { ...args, formControl },
+  }
+}
+
 const defaultArgs = {
   required: false,
   invalid: false,
@@ -684,6 +711,12 @@ WithDisplayDisabledAsLocked.args = {
   locked: false,
   description: undefined,
   displayDisabledAsLocked: true,
+}
+
+export const WithCloseOnScroll = WithCloseOnScrollTemplate.bind({}) as any
+WithCloseOnScroll.args = {
+  ...defaultArgs,
+  closeOnScroll: true,
 }
 
 const TypeaheadTemplate: StoryFn<StoryArgs> = (args: any) => {


### PR DESCRIPTION
## What has changed?
### nggv-dropdown
- Added input `closeOnScroll`, to be able to have the flexibility to toggle the function on/off
  - Default = `false`
- Created subscription `onScrollSubscription` and function `subscribeToOutsideScrollEvent`. Mirrors same functionality for `click`
  - If the dropdown is expanded and the scroll is happening **outside** of the component, that will say when the cursor is outside of the list, or when the list is too short to be scrollable even when the cursor is inside of the list, then the dropdown will close and subscription will be unsubscribed.
- If `closeOnScroll === true`, add class `close-on-scroll` to the component wrapper.
  - It's necessary to add `overscroll-behavior: none;` to the `<ul>`. Otherwise it will close the list if you are at the bottom of it and you still scroll down more. During my testing this happened a few times and I found it annoying and unexpected.
  -  A little detour was taken to add this to the `<ul>` in `dropdown-list` component. I didn't feel that it was the best way to send `closeOnScroll` boolean to the `dropdown-list` component just to add a css class, since all the logic of this is in `dropdown` component. It's against best practice, but I still believe this is the best option.
- Created new template `WithCloseOnScroll` in storybook