### PR TITLE
fix: made date input close on scroll, added dynamic position

### DIFF
--- a/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.html
+++ b/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.html
@@ -116,6 +116,8 @@
         [firstValid]="firstValid"
         [lastValid]="lastValid"
         [closingTime]="closingTime"
+        [dynamicPosition]="dynamicPosition"
+        [size]="size"
         (ngvDateChange)="onDateChange($event)"
       >
         <ng-content></ng-content>

--- a/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.ts
+++ b/libs/angular/src/v-angular/datepicker/components/date-input/date-input.component.ts
@@ -1,4 +1,6 @@
 import '../../datepicker.globals'
+import '@sebgroup/green-core/components/icon/icons/calendar.js'
+import '@sebgroup/green-core/components/icon/icons/triangle-exclamation.js'
 
 import { WeekDay } from '@angular/common'
 import {
@@ -26,9 +28,6 @@ import { startWith, takeUntil } from 'rxjs/operators'
 import { DateControlValueAccessorComponent } from '../../date-control-value-accessor/date-control-value-accessor.component'
 
 import type { CalendarType } from '../../datepicker.models'
-
-import '@sebgroup/green-core/components/icon/icons/calendar.js'
-import '@sebgroup/green-core/components/icon/icons/triangle-exclamation.js'
 
 /**
  * Date pickers simplify the task of selecting a date in a visual representation of a calendar.
@@ -100,6 +99,8 @@ export class DateInputComponent
    */
   @Input() size: 'small' | 'large' = 'large'
 
+  @Input() dynamicPosition: boolean = false
+
   /** @internal */
   // calendarIcon: IconDefinition = faCalendarDays;
 
@@ -109,6 +110,8 @@ export class DateInputComponent
   /** @internal */
   showInput$ = this.showInputDateSrc.asObservable().pipe(startWith(true))
 
+  /** Observable for listening to scrolls when the datepicker is open */
+  private documentScroll$: Observable<Event> = fromEvent(document, 'scroll')
   /** Observable for listening to clicks outside of the datepicker. */
   private documentClick$: Observable<Event> = fromEvent(document, 'click')
   /** Subject used for unsubscribe pattern on above observable. */
@@ -203,6 +206,15 @@ export class DateInputComponent
     }
     // if shown is set to true, reset unsubscribe variable
     this.datepickerClosed$.next(false)
+
+    // start listen to scroll
+    this.documentScroll$.pipe(takeUntil(this.datepickerClosed$)).subscribe({
+      next: () => {
+        // if document starts scrolling, close datepicker
+        return this.setShown(false)
+      },
+    })
+
     // start listening for clicks outside the component
     this.documentClick$.pipe(takeUntil(this.datepickerClosed$)).subscribe({
       next: (event: Event) => {

--- a/libs/angular/src/v-angular/datepicker/components/datepicker/datepicker.component.scss
+++ b/libs/angular/src/v-angular/datepicker/components/datepicker/datepicker.component.scss
@@ -48,4 +48,19 @@
     display: flex;
     padding: 0.5rem;
   }
+
+  &[data-position='top'] {
+    top: auto;
+    bottom: 100%;
+    &[data-size='large'] {
+      transform: translateY(calc(-0.5rem - 45px));
+    }
+    &[data-size='small'] {
+      transform: translateY(calc(-0.5rem - 35px));
+    }
+  }
+  &[data-position='bottom'] {
+    bottom: 0;
+    transform: translateY(100%);
+  }
 }

--- a/libs/angular/src/v-angular/datepicker/components/datepicker/datepicker.component.ts
+++ b/libs/angular/src/v-angular/datepicker/components/datepicker/datepicker.component.ts
@@ -121,7 +121,7 @@ export class DatepickerComponent implements OnInit, OnChanges, OnDestroy {
         : new Date()
     this.activeCalendar = new CalendarMonth(initDate)
 
-    this.setDropdownPosition()
+    if (this.dynamicPosition) this.setDropdownPosition()
   }
 
   ngOnDestroy() {

--- a/libs/angular/src/v-angular/datepicker/components/datepicker/datepicker.component.ts
+++ b/libs/angular/src/v-angular/datepicker/components/datepicker/datepicker.component.ts
@@ -1,12 +1,15 @@
 import { WeekDay } from '@angular/common'
 import {
   Component,
+  ElementRef,
   EventEmitter,
+  HostBinding,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
   Output,
+  Renderer2,
   SimpleChanges,
   TemplateRef,
   ViewChild,
@@ -50,6 +53,21 @@ export class DatepickerComponent implements OnInit, OnChanges, OnDestroy {
   @Input() lastValid: Date | undefined
   /** Sets a closing time for today to toggle availability for today's date. */
   @Input() closingTime: Date | undefined
+  /**
+   * When true, the datepicker will automatically choose to open above or below the input
+   * based on available space in the viewport, and will scale its height to fit if needed.
+   */
+  @Input() dynamicPosition = false
+  /** Needed to determent where to place datepicker if dropdownPosition === 'top' */
+  @Input() size: 'small' | 'large' = 'large'
+
+  @HostBinding('attr.data-position') get positionAttr() {
+    return this.datepickerPosition
+  }
+
+  @HostBinding('attr.data-size') get sizeAttr() {
+    return this.size
+  }
 
   /** @internal */
   activeCalendar!: CalendarMonth /*  = new CalendarMonth(new Date()) */
@@ -61,7 +79,15 @@ export class DatepickerComponent implements OnInit, OnChanges, OnDestroy {
   /** @internal */
   disabledDatesForActiveMonth: Date[] = []
 
+  // Indicates whether the datepicker should be displayed below ('bottom') or above ('top') the input, based on available space.
+  datepickerPosition: 'bottom' | 'top' = 'bottom'
+
   private subs: Subscription[] = []
+
+  constructor(
+    private elementRef: ElementRef,
+    private renderer: Renderer2,
+  ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (
@@ -94,6 +120,8 @@ export class DatepickerComponent implements OnInit, OnChanges, OnDestroy {
         ? new Date(this.selected)
         : new Date()
     this.activeCalendar = new CalendarMonth(initDate)
+
+    this.setDropdownPosition()
   }
 
   ngOnDestroy() {
@@ -160,5 +188,36 @@ export class DatepickerComponent implements OnInit, OnChanges, OnDestroy {
     // else, change active calendar to match the date clicked
     this.selected = date
     this.changeActiveCalendar(new CalendarMonth(date))
+  }
+
+  setDropdownPosition() {
+    const datePicker = this.elementRef.nativeElement
+    const parent = datePicker.parentElement
+
+    const rect = parent.getBoundingClientRect()
+
+    const viewportHeight = window.innerHeight
+    const spaceBelow = viewportHeight - rect.bottom
+    const spaceAbove = rect.top
+
+    const MARGIN = 10
+    const DATEPICKER_HEIGHT = 362 // 6 ROWS OF DATES, TO BE SURE
+    let maxDatepickerHeight: number
+
+    if (spaceBelow >= DATEPICKER_HEIGHT) {
+      this.datepickerPosition = 'bottom'
+      maxDatepickerHeight = DATEPICKER_HEIGHT
+    } else if (spaceAbove >= DATEPICKER_HEIGHT) {
+      this.datepickerPosition = 'top'
+      maxDatepickerHeight = DATEPICKER_HEIGHT
+    } else if (spaceBelow > spaceAbove) {
+      this.datepickerPosition = 'bottom'
+      maxDatepickerHeight = Math.max(spaceBelow - MARGIN, DATEPICKER_HEIGHT) // 10px margin, height 362px
+    } else {
+      this.datepickerPosition = 'top'
+      maxDatepickerHeight = Math.max(spaceAbove - MARGIN, DATEPICKER_HEIGHT) // 10px margin, height 362px
+    }
+
+    this.renderer.setStyle(datePicker, 'max-height', `${maxDatepickerHeight}px`)
   }
 }

--- a/libs/angular/src/v-angular/datepicker/datepicker.stories.ts
+++ b/libs/angular/src/v-angular/datepicker/datepicker.stories.ts
@@ -431,6 +431,41 @@ const CustomLockedTemplate: StoryFn<DateStoryArgs & any> = (args) => {
     },
   }
 }
+const LargeBodyTemplate: StoryFn<DateStoryArgs & any> = (args) => {
+  const dateFc = new UntypedFormControl(args.ngModel)
+
+  return {
+    template: /*html*/ `
+    <div style="height: 2000px; padding-top:800px;">
+    <nggv-dateinput
+      [label]="label"
+      [locale]="locale"
+      [dateLocale]="dateLocale"
+      [disableDates]="disableDates"
+      [disableWeekDays]="disableWeekDays"
+      [required]="required"
+      [invalid]="invalid"
+      [error]="error"
+      [errorList]="errorList"
+      [withErrorIcon]="withErrorIcon"
+      [firstDayOfWeek]="firstDayOfWeek"
+      [formControl]="formControl"
+      [locked]="locked"
+      [size]="size"
+      [displayDisabledAsLocked]="displayDisabledAsLocked"
+      [closeCalendarOnEscape]="closeCalendarOnEscape"
+      [dynamicPosition]="dynamicPosition"
+      >
+    </nggv-dateinput>
+
+    </div>
+    `,
+    props: {
+      ...args,
+      formControl: dateFc,
+    },
+  }
+}
 
 export const Primary = PrimaryTemplate.bind({})
 Primary.args = {
@@ -563,4 +598,10 @@ export const DoNotCloseCalendarOnEscClick = PrimaryTemplate.bind({})
 DoNotCloseCalendarOnEscClick.args = {
   ...Primary.args,
   closeCalendarOnEscape: false,
+}
+
+export const DynamicPosition = LargeBodyTemplate.bind({})
+DynamicPosition.args = {
+  ...Primary.args,
+  dynamicPosition: true,
 }


### PR DESCRIPTION
## What has changed?

Making `nggv-dateinput` to act more like `nggv-dropdown` by making it close on scroll and `dynamicPosition` input

### nggv-dateinput
- Added Input `dynamicPosition`, which later is being sent down to `nggv-datepicker`. 
  - Type: `boolean`
  - Default: `false`
- Created observable `documentScroll$`, which listens to scroll while the `datepicker` is open. Closes `datepicker` when emitted
- Sends `size` down to `nggv-datepicker`. 

### nggv-datepicker
- Created function `setDropdownPosition`, which triggers when the `datepicker` opens and when `dynamicPosition` is set to true. Copied logic in `nggv-dropdown` as much as possible and needed.
- Created new story where this could be tested, `Dynamic Position`