### PR TITLE
V-Angular - Radio - Create nggv-radio-group

### DIFF
--- a/libs/angular/src/v-angular/radio/index.ts
+++ b/libs/angular/src/v-angular/radio/index.ts
@@ -1,2 +1,3 @@
 export * from './radio.component'
+export * from './radio-group/radio-group.component'
 export * from './radio.module'

--- a/libs/angular/src/v-angular/radio/radio-group/radio-group.component.html
+++ b/libs/angular/src/v-angular/radio/radio-group/radio-group.component.html
@@ -1,0 +1,34 @@
+<!-- RADIO BUTTONS -->
+<div [ngClass]="direction === 'column' ? 'direction-column' : 'direction-row'">
+  <ng-content></ng-content>
+</div>
+<!-- ERRORS -->
+<ng-container *transloco="let t; read: scope">
+  <div
+    class="form-info form-info--error"
+    [attr.for]="ngControl?.name + '-radio-group'"
+    *ngIf="invalid && (error || ngControl?.invalid)"
+  >
+    <span class="error-icon">
+      <gds-icon-triangle-exclamation
+        size="16px"
+        [solid]="true"
+        *nggCoreElement
+      ></gds-icon-triangle-exclamation>
+    </span>
+    <span
+      *ngIf="error; else errorsRef"
+      [attr.data-thook]="thook + '-errorlabel'"
+    >
+      {{ error }}
+    </span>
+    <ng-template #errorsRef>
+      <span
+        *ngIf="firstError as error"
+        [attr.data-thook]="thook + '-errorlabel'"
+      >
+        {{ t('error.field' + error?.code, error?.params) }}
+      </span>
+    </ng-template>
+  </div>
+</ng-container>

--- a/libs/angular/src/v-angular/radio/radio-group/radio-group.component.scss
+++ b/libs/angular/src/v-angular/radio/radio-group/radio-group.component.scss
@@ -1,0 +1,40 @@
+:host {
+  .direction {
+    &-column {
+      display: flex;
+      flex-direction: column;
+    }
+    &-row {
+      display: flex;
+      flex-direction: row;
+    }
+  }
+
+  &.small {
+    .form-control {
+      padding: 0.25rem;
+    }
+
+    .form-control input[type='radio'] ~ i {
+      margin-right: 0.5rem;
+    }
+  }
+  .form-info {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    width: 100%;
+    font-weight: 500;
+
+    &--error {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5em;
+      color: #9f000a;
+
+      .error-icon {
+        margin-top: 0.128rem;
+        align-items: center;
+      }
+    }
+  }
+}

--- a/libs/angular/src/v-angular/radio/radio-group/radio-group.component.ts
+++ b/libs/angular/src/v-angular/radio/radio-group/radio-group.component.ts
@@ -1,0 +1,83 @@
+import '@sebgroup/green-core/components/icon/icons/triangle-exclamation.js'
+
+import {
+  ChangeDetectorRef,
+  Component,
+  HostBinding,
+  Inject,
+  Input,
+  OnInit,
+  Optional,
+  Self,
+} from '@angular/core'
+import { NgControl } from '@angular/forms'
+import { TRANSLOCO_SCOPE, TranslocoScope } from '@jsverse/transloco'
+
+import { NggvBaseControlValueAccessorComponent } from '@sebgroup/green-angular/src/v-angular/base-control-value-accessor'
+
+/**
+ * Creates a wrapper around a group of radio buttons.
+ * If there is an error to the form control connected to the radio buttons, it will be shown once below instead of below every individual radio button
+ */
+@Component({
+  selector: 'nggv-radio-group',
+  templateUrl: './radio-group.component.html',
+  styleUrls: ['./radio-group.component.scss'],
+})
+export class NggvRadioGroupComponent
+  extends NggvBaseControlValueAccessorComponent
+  implements OnInit
+{
+  /**
+   * Special property used for selecting DOM elements during automated UI testing.
+   */
+  @HostBinding('attr.data-thook') @Input() thook: string | null | undefined =
+    'radio-group'
+  /**
+   * Sets class on host element based on size input for styling
+   */
+  @HostBinding('class') @Input() size: 'small' | 'large' = 'large'
+  /**
+   * Syncs a FormControl in an existing FormGroup to a form control element by name.
+   */
+  @Input() formControlName?: string
+  /**
+   * Sets "flex-direction" of parent of radio buttons.
+   */
+  @Input() direction?: 'row' | 'column' = 'column'
+  /**
+   * Creates a new RadioComponent
+   * @param ngControl optional FormControl provided when component is used in a form, through dependency injection.
+   * @param cdr change detection reference for rendering purposes.
+   */
+  constructor(
+    @Self() @Optional() public ngControl: NgControl,
+    @Optional()
+    @Inject(TRANSLOCO_SCOPE)
+    protected translocoScope: TranslocoScope,
+    protected cdr: ChangeDetectorRef,
+  ) {
+    super(ngControl, translocoScope, cdr)
+  }
+
+  ngOnInit() {
+    super.ngOnInit()
+    this._checkName()
+  }
+
+  /** Checks that the name properties match and updates name property if only formControlName is given. */
+  private _checkName(): void {
+    if (
+      this.name &&
+      this.formControlName &&
+      this.name !== this.formControlName
+    ) {
+      throw new Error(`
+      If you define both a name and a formControlName attribute on your radio button, their values
+      must match. Ex: <input type="radio" formControlName="food" name="food">
+    `)
+    }
+
+    if (!this.name && this.formControlName) this.name = this.formControlName
+  }
+}

--- a/libs/angular/src/v-angular/radio/radio-group/radio.component.spec.ts
+++ b/libs/angular/src/v-angular/radio/radio-group/radio.component.spec.ts
@@ -1,0 +1,54 @@
+import '../../core/core.globals'
+
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing'
+import {
+  FormControl,
+  FormsModule,
+  NgControl,
+  ReactiveFormsModule,
+} from '@angular/forms'
+import { TranslocoTestingModule } from '@jsverse/transloco'
+
+import { NggvI18nTestModule } from '@sebgroup/green-angular/src/v-angular/i18n'
+import en from '../../i18n/i18n.json'
+import { NggvRadioGroupComponent } from './radio-group.component'
+
+describe('[NggvCore]', () => {
+  // ----------------------------------------------------------------------------
+  // RadioGroupComponent - constructor()
+  // ----------------------------------------------------------------------------
+  describe('RadioGroupComponent - constructor()', () => {
+    let component: NggvRadioGroupComponent
+    let fixture: ComponentFixture<NggvRadioGroupComponent>
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [NggvRadioGroupComponent],
+        providers: [{ provide: NgControl, useValue: new FormControl() }],
+        imports: [
+          FormsModule,
+          ReactiveFormsModule,
+          NggvI18nTestModule,
+          TranslocoTestingModule.forRoot({
+            langs: { en },
+            translocoConfig: {
+              availableLangs: ['en'],
+              defaultLang: 'en',
+            },
+            preloadLangs: true,
+          }),
+        ],
+      }).compileComponents()
+    }))
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NggvRadioGroupComponent)
+      component = fixture.componentInstance
+      fixture.detectChanges()
+    })
+
+    it('should create', () => {
+      expect(component).toBeTruthy()
+    })
+  })
+})

--- a/libs/angular/src/v-angular/radio/radio.component.html
+++ b/libs/angular/src/v-angular/radio/radio.component.html
@@ -48,36 +48,39 @@
   </div>
 
   <!-- ERRORS -->
-  <ng-container *transloco="let t; read: scope">
-    <div
-      class="form-info form-info--error"
-      [attr.for]="id + '-radio'"
-      *ngIf="invalid && (error || ngControl?.invalid)"
-    >
-      <span class="error-icon">
-        <gds-icon-triangle-exclamation
-          width="16"
-          height="16"
-          [solid]="true"
-          *nggCoreElement
-        ></gds-icon-triangle-exclamation>
-      </span>
-      <span
-        *ngIf="error; else errorsRef"
-        [attr.data-thook]="thook + '-errorlabel'"
+  <!-- if no nggv-radio-group is present -->
+  @if (!isGroup) {
+    <ng-container *transloco="let t; read: scope">
+      <div
+        class="form-info form-info--error"
+        [attr.for]="id + '-radio'"
+        *ngIf="invalid && (error || ngControl?.invalid)"
       >
-        {{ error }}
-      </span>
-      <ng-template #errorsRef>
+        <span class="error-icon">
+          <gds-icon-triangle-exclamation
+            width="16"
+            height="16"
+            [solid]="true"
+            *nggCoreElement
+          ></gds-icon-triangle-exclamation>
+        </span>
         <span
-          *ngIf="firstError as error"
+          *ngIf="error; else errorsRef"
           [attr.data-thook]="thook + '-errorlabel'"
         >
-          {{ t('error.field' + error?.code, error?.params) }}
+          {{ error }}
         </span>
-      </ng-template>
-    </div>
-  </ng-container>
+        <ng-template #errorsRef>
+          <span
+            *ngIf="firstError as error"
+            [attr.data-thook]="thook + '-errorlabel'"
+          >
+            {{ t('error.field' + error?.code, error?.params) }}
+          </span>
+        </ng-template>
+      </div>
+    </ng-container>
+  }
 
   <!-- CHILDREN -->
   <ng-content></ng-content>

--- a/libs/angular/src/v-angular/radio/radio.component.ts
+++ b/libs/angular/src/v-angular/radio/radio.component.ts
@@ -84,6 +84,12 @@ export class NggvRadioComponent
    */
   @Input() formControlName?: string
   /**
+   * Decides if error should be connected to each individual radio button.
+   * If true, errors will be shown in nggv-radio-group component.
+   * If false, errors will be show below each radio button
+   */
+  isGroup: boolean = false
+  /**
    * Creates a new RadioComponent
    * @param ngControl optional FormControl provided when component is used in a form, through dependency injection.
    * @param registry internal registry used to uncheck radio buttons with the matching name, through dependency injection.
@@ -104,6 +110,16 @@ export class NggvRadioComponent
     super.ngOnInit()
     this._checkName()
     this.registry.add(this.ngControl, this)
+    // Check if nggv-radio-group is present connected to the same formControl
+    if (
+      Array.from(
+        document.querySelectorAll(
+          `nggv-radio-group[formcontrolname=${this.name}]`,
+        ),
+      ).length
+    ) {
+      this.isGroup = true
+    }
   }
 
   ngOnDestroy() {

--- a/libs/angular/src/v-angular/radio/radio.module.ts
+++ b/libs/angular/src/v-angular/radio/radio.module.ts
@@ -3,12 +3,13 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
 
 import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
 import { NggvI18nModule } from '@sebgroup/green-angular/src/v-angular/i18n'
+import { NggvRadioGroupComponent } from './radio-group/radio-group.component'
 import { NggvRadioComponent } from './radio.component'
 
 @NgModule({
-  declarations: [NggvRadioComponent],
+  declarations: [NggvRadioComponent, NggvRadioGroupComponent],
   imports: [CommonModule, NggvI18nModule, NggCoreWrapperModule],
-  exports: [NggvRadioComponent],
+  exports: [NggvRadioComponent, NggvRadioGroupComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class NggvRadioModule {}

--- a/libs/angular/src/v-angular/radio/radio.stories.ts
+++ b/libs/angular/src/v-angular/radio/radio.stories.ts
@@ -3,7 +3,12 @@ import '@sebgroup/green-core/components/icon/icons/triangle-exclamation.js'
 
 import { CommonModule } from '@angular/common'
 import { CUSTOM_ELEMENTS_SCHEMA, importProvidersFrom } from '@angular/core'
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms'
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms'
 import {
   applicationConfig,
   Meta,
@@ -13,6 +18,7 @@ import {
 
 import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
 import { NggvI18nModule } from '@sebgroup/green-angular/src/v-angular/i18n'
+import { NggvRadioGroupComponent } from './radio-group/radio-group.component'
 import { NggvRadioComponent } from './radio.component'
 
 interface StoryInputListener {
@@ -28,6 +34,7 @@ const meta: Meta<NggvRadioComponent> = {
       providers: [importProvidersFrom(NggvI18nModule)],
     }),
     moduleMetadata({
+      declarations: [NggvRadioGroupComponent],
       imports: [
         CommonModule,
         FormsModule,
@@ -151,6 +158,64 @@ const TemplateWithFormControl: StoryFn<NggvRadioComponent & any> = (
   }
 }
 
+const TemplateRadioGroup: StoryFn<NggvRadioComponent & any> = (
+  args: NggvRadioComponent & any,
+) => {
+  const ctrl = new FormControl({ value: args.selected, name: args.name })
+  const grp = new FormGroup({
+    imaginaryFormControl: ctrl,
+  })
+
+  return {
+    template: /*html*/ `
+    <div [formGroup]="formGroup">
+      <nggv-radio-group direction="row"
+          formControlName="imaginaryFormControl"
+          [error]="error"
+          [invalid]="invalid">
+        <nggv-radio
+          formControlName="imaginaryFormControl"
+          [label]="label"
+          [name]="formControlName"
+          [value]="name + '1'"
+          [size]="size"
+          [invalid]="invalid"
+          [error]="error"
+          [ngModel]="selected"
+          (ngModelChange)="action($event)">
+        </nggv-radio>
+        <nggv-radio
+        formControlName="imaginaryFormControl"
+          [label]="label"
+          [name]="formControlName"
+          [size]="size"
+          [error]="error"
+          [invalid]="invalid"
+          [value]="name + '2'"
+          [ngModel]="selected"
+          (ngModelChange)="action($event)">
+        </nggv-radio>
+        <nggv-radio
+        formControlName="imaginaryFormControl"
+          [label]="label"
+          [name]="formControlName"
+          [size]="size"
+          [error]="error"
+          [invalid]="invalid"
+          [value]="name + '3'"
+          [ngModel]="selected"
+          (ngModelChange)="action($event)">
+        </nggv-radio>
+      </nggv-radio-group>
+    </div>
+  `,
+    props: {
+      ...args,
+      formGroup: grp,
+    },
+  }
+}
+
 export const Primary = Template.bind({})
 Primary.args = {
   label: 'Radio label',
@@ -172,4 +237,11 @@ WithDisplayDisabledAsLocked.args = {
   ...Primary.args,
   locked: false,
   displayDisabledAsLocked: true,
+}
+
+export const RadioGroup = TemplateRadioGroup.bind({})
+RadioGroup.args = {
+  ...Primary.args,
+  invalid: true,
+  error: 'this is an error',
 }


### PR DESCRIPTION
## What's changed?

- Created new component `nggv-radio-group`, connected to `nggv-radio`
   - Made the most basic radio-group to be able to handle errors for a group of radio buttons connected to the same form control
   - Literally only supports error handling, nothing else, but it's a start 😆 
- Did minor styling-tweaks to the error field in `nggv-radio-group`, compared to `nggv-radio`, which is left alone
   - Changed `gds-icon-triangle-exclamation` `width:16px` and `height:16px` to `size:16px`, to match the rest of the library (it's now smaller)
   - Removed `margin-top: -0.25rem` and `padding-left: 1rem;` from `.form-info`, to match the rest of the library
- Added `@Input() direction: string` to `nggv-radio-group`
   - For the user to be able to change `flex-direction` of their radio buttons.
   - Values: `"row"` or `"column"`
   - Default:  `"column"`
   - Optional
- Created variable `isGroup: boolean` in `nggv-radio`
   - On init, check the `document` if a `nggv-radio-group` with the same `formControlName` exists and changes `isGroup` to `true`
   - If `isGroup = true`, the error message will not display underneath the radio button. The `nggv-radio-group` will take care of that
   - Default: `false`
- Created `RadioGroup`-story in Storybook for `Radio` to try out this new functionality 